### PR TITLE
Removed absolute x,y value on Android on drag end event

### DIFF
--- a/android/src/ti/draggable/DraggableGesture.java
+++ b/android/src/ti/draggable/DraggableGesture.java
@@ -245,8 +245,8 @@ public class DraggableGesture implements OnTouchListener
 
 			this.setViewPosition(draggableProxy, viewToDrag, (float) topEdge, (float) leftEdge, ensureBottomValue, ensureRightValue);
 
-			distanceX += Math.abs(lastLeft - leftEdge);
-			distanceY += Math.abs(lastTop - topEdge);
+			distanceX += (lastLeft - leftEdge);
+			distanceY += (lastTop - topEdge);
 			lastLeft = leftEdge;
 			lastTop = topEdge;
 


### PR DESCRIPTION
Absolute values on Android didn't allow to understand which was the correct direction of drag action.